### PR TITLE
csv_import.php addObject function small bug

### DIFF
--- a/csv_import.php
+++ b/csv_import.php
@@ -338,7 +338,7 @@ function addObject($csvdata,$row_number)
 	}
 
 	// When available, import the port information
-	if ((count($ifName) > 0) & (count($ifType > 0)) & (count($ifName) == count($ifType)) ) 
+	if ((count($ifName) > 0) && (count($ifType > 0)) && (count($ifName) == count($ifType)) && (strlen($ifName ) > 0) )
 	{
 		// temporary disable autocreation of ports
 		$tempAUTOPORTS_CONFIG =  getConfigVar ('AUTOPORTS_CONFIG');


### PR DESCRIPTION
Added  (strlen($ifName ) > 0)  as a verification since adding an object without ports would fail otherwise.

When adding a new object, counting the value of $ifName doesn't filter my tests of objects without ports.

--------------- before ------------------------------
example test:
"OBJECT;PATCHPANEL;this is a test entry; this is a test entry"
result:
"Internal error
## Argument 'port_type_id' of value '' is invalid (format error)."

--------------- after------------------------------
After adding the strlen verification it's behaving properly with my test:
"OBJECT;PATCHPANEL;this is a test entry; this is a test entry"
result (the port validation is correct, as I didn't provide any):
"Importing from manual input field
No valid Port information found, skipping port import."
![image](https://cloud.githubusercontent.com/assets/5605776/4109722/c0b68288-31e8-11e4-9fb3-48428d0aa660.png)

---
