### PR TITLE
fix CABLELINK

### DIFF
--- a/csv_import.php
+++ b/csv_import.php
@@ -663,7 +663,7 @@ function addCableLink($csvdata,$row_number)
 		$linkresult = linkPorts ($db_result_a['id'], $db_result_b['id'], $cable_id);
 
 		// port already linked
-		if($linkresult)
+		if(!is_numeric($linkresult))
 		{
 			showError("line $row_number: Import CableLink ". $cable_id." FAILED. $object_a $port_a -> $object_b $port_b \"".$linkresult."\"");
 			return FALSE;


### PR DESCRIPTION
 linkPorts now returns rows affected and throws exception on existing links